### PR TITLE
Moved mocking tables and UUIDs from class to trait

### DIFF
--- a/tests/MockTablesAndUuidsTrait.php
+++ b/tests/MockTablesAndUuidsTrait.php
@@ -7,10 +7,9 @@ namespace Verbanent\Uuid\Test;
 use Illuminate\Container\Container;
 use Illuminate\Database\Capsule\Manager as Capsule;
 use Illuminate\Events\Dispatcher;
-use PHPUnit\Framework\TestCase;
 use Ramsey\Uuid\Uuid;
 
-class SetUpTrait extends TestCase
+trait MockTablesAndUuidsTrait
 {
     protected $id = '11e9469d-b942-b7e6-bc69-8df4f180e5a9';
     protected $uuid = '11e9469d-b942-b7e6-bc69-8df4f180e5a9';
@@ -20,7 +19,7 @@ class SetUpTrait extends TestCase
     {
         $capsule = new Capsule();
         $capsule->addConnection([
-            'driver'   => 'sqlite',
+            'driver' => 'sqlite',
             'database' => ':memory:',
         ]);
         $capsule->setEventDispatcher(new Dispatcher(new Container()));

--- a/tests/Traits/BinaryIdSupportableTraitTest.php
+++ b/tests/Traits/BinaryIdSupportableTraitTest.php
@@ -4,16 +4,19 @@ declare(strict_types=1);
 
 namespace Verbanent\Uuid\Test\Traits;
 
+use PHPUnit\Framework\TestCase;
 use Verbanent\Uuid\Exceptions\AccessedUnsetUuidPropertyException;
 use Verbanent\Uuid\Test\Example\BinaryId\CatIdModel;
 use Verbanent\Uuid\Test\Example\BinaryId\CowIdModel;
 use Verbanent\Uuid\Test\Example\BinaryId\DogIdModel;
 use Verbanent\Uuid\Test\Example\BinaryId\HorseIdModel;
 use Verbanent\Uuid\Test\Example\BinaryId\PigIdModel;
-use Verbanent\Uuid\Test\SetUpTrait;
+use Verbanent\Uuid\Test\MockTablesAndUuidsTrait;
 
-class BinaryIdSupportableTraitTest extends SetUpTrait
+class BinaryIdSupportableTraitTest extends TestCase
 {
+    use MockTablesAndUuidsTrait;
+
     public function testNotEmptyTable()
     {
         $cat = new CatIdModel();

--- a/tests/Traits/BinaryUuidSupportableTraitTest.php
+++ b/tests/Traits/BinaryUuidSupportableTraitTest.php
@@ -4,16 +4,19 @@ declare(strict_types=1);
 
 namespace Verbanent\Uuid\Test\Traits;
 
+use PHPUnit\Framework\TestCase;
 use Verbanent\Uuid\Exceptions\AccessedUnsetUuidPropertyException;
 use Verbanent\Uuid\Test\Example\Binary\CatUuidModel;
 use Verbanent\Uuid\Test\Example\Binary\CowUuidModel;
 use Verbanent\Uuid\Test\Example\Binary\DogUuidModel;
 use Verbanent\Uuid\Test\Example\Binary\HorseUuidModel;
 use Verbanent\Uuid\Test\Example\Binary\PigUuidModel;
-use Verbanent\Uuid\Test\SetUpTrait;
+use Verbanent\Uuid\Test\MockTablesAndUuidsTrait;
 
-class BinaryUuidSupportableTraitTest extends SetUpTrait
+class BinaryUuidSupportableTraitTest extends TestCase
 {
+    use MockTablesAndUuidsTrait;
+
     public function testNotEmptyTable()
     {
         $cat = new CatUuidModel();

--- a/tests/Traits/ForeignBinaryIdSupportableTraitTest.php
+++ b/tests/Traits/ForeignBinaryIdSupportableTraitTest.php
@@ -5,19 +5,22 @@ declare(strict_types=1);
 namespace Verbanent\Uuid\Test\Traits;
 
 use Illuminate\Database\Eloquent\Collection;
+use PHPUnit\Framework\TestCase;
 use Verbanent\Uuid\Test\Example\ForeignBinaryId\ChickenIdModel;
 use Verbanent\Uuid\Test\Example\ForeignBinaryId\DuckIdModel;
 use Verbanent\Uuid\Test\Example\ForeignBinaryId\MouseIdModel;
 use Verbanent\Uuid\Test\Example\ForeignBinaryId\RabbitIdModel;
 use Verbanent\Uuid\Test\Example\ForeignBinaryId\SnakeIdModel;
-use Verbanent\Uuid\Test\SetUpTrait;
+use Verbanent\Uuid\Test\MockTablesAndUuidsTrait;
 
-class ForeignBinaryIdSupportableTraitTest extends SetUpTrait
+class ForeignBinaryIdSupportableTraitTest extends TestCase
 {
+    use MockTablesAndUuidsTrait;
+
     public function testCreatingModelWithBinaryForeignUuid()
     {
         ChickenIdModel::create([
-            'id'        => $this->uuid,
+            'id' => $this->uuid,
             'foreignUuid' => $this->binaryUuid,
         ]);
 
@@ -51,7 +54,7 @@ class ForeignBinaryIdSupportableTraitTest extends SetUpTrait
     public function testReadableForeignUuid()
     {
         RabbitIdModel::create([
-            'id'        => $this->uuid,
+            'id' => $this->uuid,
             'foreignUuid' => $this->uuid,
         ]);
 

--- a/tests/Traits/ForeignBinaryUuidSupportableTraitTest.php
+++ b/tests/Traits/ForeignBinaryUuidSupportableTraitTest.php
@@ -5,19 +5,22 @@ declare(strict_types=1);
 namespace Verbanent\Uuid\Test\Traits;
 
 use Illuminate\Database\Eloquent\Collection;
+use PHPUnit\Framework\TestCase;
 use Verbanent\Uuid\Test\Example\ForeignBinary\ChickenUuidModel;
 use Verbanent\Uuid\Test\Example\ForeignBinary\DuckUuidModel;
 use Verbanent\Uuid\Test\Example\ForeignBinary\MouseUuidModel;
 use Verbanent\Uuid\Test\Example\ForeignBinary\RabbitUuidModel;
 use Verbanent\Uuid\Test\Example\ForeignBinary\SnakeUuidModel;
-use Verbanent\Uuid\Test\SetUpTrait;
+use Verbanent\Uuid\Test\MockTablesAndUuidsTrait;
 
-class ForeignBinaryUuidSupportableTraitTest extends SetUpTrait
+class ForeignBinaryUuidSupportableTraitTest extends TestCase
 {
+    use MockTablesAndUuidsTrait;
+
     public function testCreatingModelWithBinaryForeignUuid()
     {
         ChickenUuidModel::create([
-            'uuid'        => $this->uuid,
+            'uuid' => $this->uuid,
             'foreignUuid' => $this->binaryUuid,
         ]);
 
@@ -51,7 +54,7 @@ class ForeignBinaryUuidSupportableTraitTest extends SetUpTrait
     public function testReadableForeignUuid()
     {
         RabbitUuidModel::create([
-            'uuid'        => $this->uuid,
+            'uuid' => $this->uuid,
             'foreignUuid' => $this->uuid,
         ]);
 


### PR DESCRIPTION
- Old tests had a class which acted like a trait - it's a trait now.