### PR TITLE
Fixed security advisories in dev dependencies

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -39,8 +39,8 @@
         "ramsey/uuid": "^3.8|^4"
     },
     "require-dev": {
-        "phpunit/phpunit": "^9",
-        "laravel/framework": "^6.20.26|^7|^8|^9|^10.48.29|^11|^12",
+        "phpunit/phpunit": "^9.6.33",
+        "laravel/framework": "^12.61.1",
         "mockery/mockery": "^1"
     },
     "type": "library"


### PR DESCRIPTION
Closes the two open Dependabot alerts on this repository, plus one more that `composer audit` surfaced.

## Advisories

| Package | Advisory | Severity | Patched in |
| --- | --- | --- | --- |
| `laravel/framework` | [GHSA-5vg9-5847-vvmq](https://github.com/advisories/GHSA-5vg9-5847-vvmq) — CRLF injection in the default email rule | high | 12.60.0 |
| `laravel/framework` | [GHSA-crmm-hgp2-wgrp](https://github.com/advisories/GHSA-crmm-hgp2-wgrp) — temporary signed URL path confusion | medium | 12.61.1 |
| `phpunit/phpunit` | [GHSA-vvj3-c3rp-c85p](https://github.com/advisories/GHSA-vvj3-c3rp-c85p) — unsafe deserialization in PHPT code coverage handling | high | 9.6.33 |

## Change

```diff
-        "phpunit/phpunit": "^9",
-        "laravel/framework": "^6.20.26|^7|^8|^9|^10.48.29|^11|^12",
+        "phpunit/phpunit": "^9.6.33",
+        "laravel/framework": "^12.61.1",
```

Both packages are `require-dev` only. Nothing changes for people installing this library — `require` is untouched (`php: ^7.3|^8`, `ramsey/uuid: ^3.8|^4`), and Laravel is never pulled in as a runtime dependency.

## Why the Laravel union had to go

Both Laravel advisories declare their affected range as `< 12.61.1` (plus a 13.x range) rather than one range per branch — Laravel only ships security patches for supported branches, so 6.x–11.x have no patched release. Any constraint that still allows `^6.20.26|^7|^8|^9|^10.48.29|^11` therefore leaves a vulnerable version resolvable and keeps the alerts open. Pinning the dev requirement to `^12.61.1` is the only way to clear them.

Practical impact: the test suite is now developed and run against Laravel 12 only. CI already installed just the highest allowed version, so effective coverage is unchanged; contributors now need PHP 8.2+ to install dev dependencies (Laravel 12's own requirement).

## Verification

- `composer audit` — no advisories remaining (was: 1 for phpunit, plus the 2 Dependabot alerts against the manifest).
- `vendor/bin/phpunit` — 30 tests, 48 assertions, same result as before the bump.
  - One pre-existing error, unrelated to this change and reproducible on `main`: `BinaryUuidServiceProviderLegacyGrammarTest` fails locally on PHP 8.5 because `ReflectionMethod::setAccessible()` is deprecated there and the test runs in an isolated process. CI runs PHP 8.2 and is unaffected. Worth a separate cleanup — the `setAccessible(true)` calls in `tests/Grammars/MySqlGrammarTest.php:33` and `tests/Providers/BinaryUuidServiceProviderLegacyGrammarTest.php:37` have been no-ops since PHP 8.1.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hfqNHa1T563aGng4ecmH1