### PR TITLE
Fixed the SonarCloud analysis step

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -19,7 +19,7 @@ jobs:
                     coverage: xdebug
             -   run: composer install --no-interaction --no-progress --prefer-dist
             -   run: php -d xdebug.mode=coverage vendor/bin/phpunit --coverage-clover coverage.xml
-            -   uses: SonarSource/sonarcloud-github-action@e44258b109568baa0df60ed515909fc6c72cba92
+            -   uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
                 env:
                     SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}
                     GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}


### PR DESCRIPTION
Follow-up to #24, kept separate so the security bump stays a one-line diff.

## Problem

The SonarCloud check fails on every run now, before any analysis happens:

```
ERROR: Error during SonarScanner execution
java.lang.IllegalStateException: Java 17 is not supported.
Please upgrade to Java 21 or newer, or use JRE auto-provisioning ...
```

The pinned `SonarSource/sonarcloud-github-action@e442580` ships a scanner image with Java 17, and SonarQube Cloud dropped support for it. The last green run on this workflow was in January; the change is server-side, so nothing in the repository had to change for it to start failing. `SonarSource/sonarcloud-github-action` is also deprecated upstream in favour of `SonarSource/sonarqube-scan-action`.

## Change

```diff
--   uses: SonarSource/sonarcloud-github-action@e44258b109568baa0df60ed515909fc6c72cba92
+-   uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f # v8.2.1
```

Pinned by commit SHA, matching how `actions/checkout` and `setup-php` are pinned here. Everything else stays as it is — the scanner still picks up `sonar-project.properties` (organization, project key, `coverage.xml` path) and authenticates with `SONAR_TOKEN`, and the PHP/PHPUnit steps are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hfqNHa1T563aGng4ecmH1