### PR TITLE
Fixed the StyleCI configuration

### DIFF
--- a/.styleci.yml
+++ b/.styleci.yml
@@ -1,5 +1,5 @@
 risky: false
-version: 7
+version: 8.1
 preset: psr12
 finder:
     exclude:


### PR DESCRIPTION
`continuous-integration/styleci` has been reporting **"The analysis was misconfigured"** on every branch and push. That status means StyleCI rejected the config before running any fixers — it is not a style violation in the code.

The cause is the `version` key. Per [StyleCI's PHP-only configuration docs](https://docs.styleci.io/standalone-php#version):

> It is possible to set the PHP version your code will be parsed using using the `version` option. **8.1, 8.2, 8.3, and 8.4 are the allowed values**, and additionally, `8` is an alias for `8.4`. PHP version 8.4 is the default version.

`.styleci.yml` pins `version: 7`, which is no longer in that set.

```diff
 risky: false
-version: 7
+version: 8.1
 preset: psr12
```

I picked `8.1` — the lowest value StyleCI still accepts — to stay as close as possible to the PHP versions this library supports (`^7.3|^8`). The option only selects the parser, and with `risky: false` the `psr12` preset applies no version-specific rewrites, so nothing here changes for code running on PHP 7.3. Everything else in the config (`preset: psr12`, the finder rules) is still valid and untouched.

The StyleCI check on this PR is the verification: if it comes back green instead of "misconfigured", the config is accepted again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hfqNHa1T563aGng4ecmH1