### PR TITLE
Bumped the pinned actions to Node 24 releases

### DIFF
--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -10,10 +10,10 @@ jobs:
             github.event.pull_request.head.repo.full_name == github.repository) }}
         runs-on: ubuntu-latest
         steps:
-            -   uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5
+            -   uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
                 with:
                     fetch-depth: 0
-            -   uses: shivammathur/setup-php@44454db4f0199b8b9685a5d763dc37cbf79108e1
+            -   uses: shivammathur/setup-php@f3e473d116dcccaddc5834248c87452386958240 # 2.37.2
                 with:
                     php-version: '8.2'
                     coverage: xdebug


### PR DESCRIPTION
Follow-up to the green run on `main`, which passed but carried this annotation:

```
Node.js 20 is deprecated. The following actions target Node.js 20 but are being
forced to run on Node.js 24: actions/checkout@34e1148, shivammathur/setup-php@44454db
```

GitHub is currently papering over the gap by running these actions on Node 24 anyway. That forcing is temporary, so the pins need to move to releases that declare the newer runtime themselves.

## Change

| Action | Was | Now | `runs.using` |
| --- | --- | --- | --- |
| `actions/checkout` | `34e1148` (Nov 2025) | `3d3c42e` — v7.0.1 | `node24` |
| `shivammathur/setup-php` | `44454db` (Nov 2025) | `f3e473d` — 2.37.2 | `node24` |

Both stay pinned by commit SHA, with the version in a trailing comment so the pins are readable at a glance — same style as the `sonarqube-scan-action` pin. `runs.using: node24` verified in each action's `action.yml` at the pinned SHA.

No inputs changed: `checkout` keeps `fetch-depth: 0` (SonarCloud needs the full history for blame data), and `setup-php` keeps PHP 8.2 with Xdebug coverage.

Verification is the run on this PR — the deprecation annotation should be gone, with the quality gate still passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hfqNHa1T563aGng4ecmH1