### PR TITLE
Added clear errors for a misconfigured UUID column

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,23 @@ Per-model override still works and takes precedence:
 protected $uuidColumn = 'custom_uuid';
 ```
 
+## Troubleshooting
+
+When the package reads a column that does not hold a binary UUID, it says so
+directly instead of letting `ramsey/uuid` fail on the raw value:
+
+```
+Column "id" on App\Models\Category does not contain a 16-byte binary UUID
+(found a 4-byte string). Point $uuidColumn on the model, or
+binary-uuid.default_column, at the column holding the binary UUID.
+```
+
+UUIDs are stored as 16 raw bytes, so the column the package reads has to be the
+binary one — set it per model with `protected $uuidColumn = 'uuid';` or globally
+with `BINARY_UUID_DEFAULT_COLUMN`. Assigning a value that is neither a UUID in
+string form nor 16 raw bytes throws `InvalidBinaryUuidException` while the model
+is being created, instead of writing it to the database.
+
 ## Unit tests
 
 Run this command if you want to check unit tests:

--- a/src/Exceptions/InvalidBinaryUuidException.php
+++ b/src/Exceptions/InvalidBinaryUuidException.php
@@ -41,7 +41,7 @@ class InvalidBinaryUuidException extends \RuntimeException
     {
         return new self(sprintf(
             'Cannot store the value assigned to column "%s" on %s: a UUID in string form '
-            .'or 16 raw bytes is expected, found %s.',
+            . 'or 16 raw bytes is expected, found %s.',
             $column,
             $model,
             self::describe($value)
@@ -82,6 +82,6 @@ class InvalidBinaryUuidException extends \RuntimeException
         }
 
         return 'Point $uuidColumn on the model, or binary-uuid.default_column, '
-            .'at the column holding the binary UUID.';
+            . 'at the column holding the binary UUID.';
     }
 }

--- a/src/Exceptions/InvalidBinaryUuidException.php
+++ b/src/Exceptions/InvalidBinaryUuidException.php
@@ -1,0 +1,87 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Verbanent\Uuid\Exceptions;
+
+use Ramsey\Uuid\Uuid;
+
+class InvalidBinaryUuidException extends \RuntimeException
+{
+    /**
+     * A column read as a binary UUID holds something else.
+     *
+     * @param string $model
+     * @param string $column
+     * @param mixed  $value
+     *
+     * @return self
+     */
+    public static function forColumn(string $model, string $column, $value): self
+    {
+        return new self(sprintf(
+            'Column "%s" on %s does not contain a 16-byte binary UUID (found %s). %s',
+            $column,
+            $model,
+            self::describe($value),
+            self::hint($value)
+        ));
+    }
+
+    /**
+     * A value assigned to the UUID column cannot be stored as a binary UUID.
+     *
+     * @param string $model
+     * @param string $column
+     * @param mixed  $value
+     *
+     * @return self
+     */
+    public static function forAssignedValue(string $model, string $column, $value): self
+    {
+        return new self(sprintf(
+            'Cannot store the value assigned to column "%s" on %s: a UUID in string form '
+            .'or 16 raw bytes is expected, found %s.',
+            $column,
+            $model,
+            self::describe($value)
+        ));
+    }
+
+    /**
+     * Describe the offending value without leaking its contents.
+     *
+     * @param mixed $value
+     *
+     * @return string
+     */
+    private static function describe($value): string
+    {
+        if (!is_string($value)) {
+            return sprintf('a value of type %s', gettype($value));
+        }
+
+        if (Uuid::isValid($value)) {
+            return 'a UUID in string form';
+        }
+
+        return sprintf('a %d-byte string', strlen($value));
+    }
+
+    /**
+     * Suggest the most likely fix for the offending value.
+     *
+     * @param mixed $value
+     *
+     * @return string
+     */
+    private static function hint($value): string
+    {
+        if (is_string($value) && Uuid::isValid($value)) {
+            return 'UUIDs are stored as 16 raw bytes, so this column was written without the package.';
+        }
+
+        return 'Point $uuidColumn on the model, or binary-uuid.default_column, '
+            .'at the column holding the binary UUID.';
+    }
+}

--- a/src/Traits/BinaryUuidSupportableTrait.php
+++ b/src/Traits/BinaryUuidSupportableTrait.php
@@ -10,6 +10,7 @@ use Illuminate\Database\Eloquent\Model;
 use Ramsey\Uuid\Codec\OrderedTimeCodec;
 use Ramsey\Uuid\Uuid;
 use Verbanent\Uuid\Exceptions\AccessedUnsetUuidPropertyException;
+use Verbanent\Uuid\Exceptions\InvalidBinaryUuidException;
 
 /**
  * Trait for models with binary UUID.
@@ -63,14 +64,17 @@ trait BinaryUuidSupportableTrait
         static::creating(
             function (Model $model) {
                 $uuid = $model->getUuidColumn();
+                $value = $model->attributes[$uuid] ?? null;
 
                 /** @var Model|BinaryUuidSupportableTrait $model */
-                if (!isset($model->attributes[$uuid])) {
+                if ($value === null) {
                     $model->$uuid = $model->generateUuid();
-                } elseif (Uuid::isValid($model->attributes[$uuid])) {
-                    $model->$uuid = Uuid::fromString($model->attributes[$uuid])->getBytes();
-                } elseif (is_string($model->attributes[$uuid]) && strlen($model->attributes[$uuid]) === 16) {
-                    $model->$uuid = $model->attributes[$uuid];
+                } elseif (is_string($value) && Uuid::isValid($value)) {
+                    $model->$uuid = Uuid::fromString($value)->getBytes();
+                } elseif (is_string($value) && strlen($value) === 16) {
+                    $model->$uuid = $value;
+                } else {
+                    throw InvalidBinaryUuidException::forAssignedValue(get_class($model), $uuid, $value);
                 }
 
                 if (isset($model->readable) && $model->readable) {
@@ -98,6 +102,8 @@ trait BinaryUuidSupportableTrait
     /**
      * Returns string form of UUID.
      *
+     * @throws AccessedUnsetUuidPropertyException
+     * @throws InvalidBinaryUuidException
      * @throws Exception
      *
      * @return string
@@ -107,12 +113,20 @@ trait BinaryUuidSupportableTrait
         $uuid = $this->getUuidColumn();
 
         if (!isset($this->$uuid)) {
-            throw new AccessedUnsetUuidPropertyException(
-                'Cannot get UUID property for not saved model'
-            );
+            throw new AccessedUnsetUuidPropertyException(sprintf(
+                'Cannot get UUID from column "%s" for not saved model %s',
+                $uuid,
+                static::class
+            ));
         }
 
-        return Uuid::fromBytes($this->$uuid)->toString();
+        $value = $this->$uuid;
+
+        if (!is_string($value) || strlen($value) !== 16) {
+            throw InvalidBinaryUuidException::forColumn(static::class, $uuid, $value);
+        }
+
+        return Uuid::fromBytes($value)->toString();
     }
 
     /**

--- a/src/Traits/ForeignBinaryUuidSupportableTrait.php
+++ b/src/Traits/ForeignBinaryUuidSupportableTrait.php
@@ -7,6 +7,7 @@ namespace Verbanent\Uuid\Traits;
 use Illuminate\Database\Eloquent\Collection;
 use Illuminate\Database\Eloquent\Model;
 use Ramsey\Uuid\Uuid;
+use Verbanent\Uuid\Exceptions\InvalidBinaryUuidException;
 
 /**
  * Trait for models with binary UUID in other columns than just a primary key.
@@ -132,10 +133,18 @@ trait ForeignBinaryUuidSupportableTrait
      *
      * @param string $columnName
      *
+     * @throws InvalidBinaryUuidException
+     *
      * @return string
      */
     public function foreignUuid(string $columnName): string
     {
-        return Uuid::fromBytes($this->$columnName)->toString();
+        $value = $this->$columnName;
+
+        if (!is_string($value) || strlen($value) !== 16) {
+            throw InvalidBinaryUuidException::forColumn(static::class, $columnName, $value);
+        }
+
+        return Uuid::fromBytes($value)->toString();
     }
 }

--- a/tests/Example/Binary/GoatUuidModel.php
+++ b/tests/Example/Binary/GoatUuidModel.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Verbanent\Uuid\Test\Example\Binary;
+
+use Verbanent\Uuid\Test\Example\AbstractExampleUuidModel;
+
+/**
+ * Goat model.
+ */
+class GoatUuidModel extends AbstractExampleUuidModel
+{
+    //
+}

--- a/tests/Example/Binary/SheepUuidModel.php
+++ b/tests/Example/Binary/SheepUuidModel.php
@@ -1,0 +1,15 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Verbanent\Uuid\Test\Example\Binary;
+
+use Verbanent\Uuid\Test\Example\AbstractExampleUuidModel;
+
+/**
+ * Sheep model.
+ */
+class SheepUuidModel extends AbstractExampleUuidModel
+{
+    //
+}

--- a/tests/Traits/BinaryUuidSupportableTraitTest.php
+++ b/tests/Traits/BinaryUuidSupportableTraitTest.php
@@ -6,11 +6,14 @@ namespace Verbanent\Uuid\Test\Traits;
 
 use PHPUnit\Framework\TestCase;
 use Verbanent\Uuid\Exceptions\AccessedUnsetUuidPropertyException;
+use Verbanent\Uuid\Exceptions\InvalidBinaryUuidException;
 use Verbanent\Uuid\Test\Example\Binary\CatUuidModel;
 use Verbanent\Uuid\Test\Example\Binary\CowUuidModel;
 use Verbanent\Uuid\Test\Example\Binary\DogUuidModel;
+use Verbanent\Uuid\Test\Example\Binary\GoatUuidModel;
 use Verbanent\Uuid\Test\Example\Binary\HorseUuidModel;
 use Verbanent\Uuid\Test\Example\Binary\PigUuidModel;
+use Verbanent\Uuid\Test\Example\Binary\SheepUuidModel;
 use Verbanent\Uuid\Test\MockTablesAndUuidsTrait;
 
 class BinaryUuidSupportableTraitTest extends TestCase
@@ -68,5 +71,45 @@ class BinaryUuidSupportableTraitTest extends TestCase
     {
         $binaryUuid = HorseUuidModel::encodeUuid($this->uuid);
         $this->assertEquals($this->binaryUuid, $binaryUuid);
+    }
+
+    public function testUuidColumnHoldsSomethingElse()
+    {
+        $horse = new HorseUuidModel();
+        $horse->setRawAttributes(['uuid' => 'uuid']);
+
+        $this->expectException(InvalidBinaryUuidException::class);
+        $this->expectExceptionMessage('does not contain a 16-byte binary UUID (found a 4-byte string)');
+        $horse->uuid();
+    }
+
+    public function testUuidColumnHoldsUuidInStringForm()
+    {
+        $horse = new HorseUuidModel();
+        $horse->setRawAttributes(['uuid' => $this->uuid]);
+
+        $this->expectException(InvalidBinaryUuidException::class);
+        $this->expectExceptionMessage('found a UUID in string form');
+        $horse->uuid();
+    }
+
+    public function testSetNotAnUuidAsProperty()
+    {
+        $sheep = new SheepUuidModel();
+        $sheep->uuid = 'not-an-uuid';
+
+        $this->expectException(InvalidBinaryUuidException::class);
+        $this->expectExceptionMessage('Cannot store the value assigned to column "uuid"');
+        $sheep->save();
+    }
+
+    public function testSetNonStringAsProperty()
+    {
+        $goat = new GoatUuidModel();
+        $goat->uuid = 3;
+
+        $this->expectException(InvalidBinaryUuidException::class);
+        $this->expectExceptionMessage('found a value of type integer');
+        $goat->save();
     }
 }

--- a/tests/Traits/ForeignBinaryUuidSupportableTraitTest.php
+++ b/tests/Traits/ForeignBinaryUuidSupportableTraitTest.php
@@ -11,6 +11,7 @@ use Verbanent\Uuid\Test\Example\ForeignBinary\DuckUuidModel;
 use Verbanent\Uuid\Test\Example\ForeignBinary\MouseUuidModel;
 use Verbanent\Uuid\Test\Example\ForeignBinary\RabbitUuidModel;
 use Verbanent\Uuid\Test\Example\ForeignBinary\SnakeUuidModel;
+use Verbanent\Uuid\Exceptions\InvalidBinaryUuidException;
 use Verbanent\Uuid\Test\MockTablesAndUuidsTrait;
 
 class ForeignBinaryUuidSupportableTraitTest extends TestCase
@@ -72,5 +73,15 @@ class ForeignBinaryUuidSupportableTraitTest extends TestCase
         $snake->save();
 
         $this->assertEquals($incorrectUuid, $snake->foreignUuid);
+    }
+
+    public function testForeignUuidColumnHoldsSomethingElse()
+    {
+        $duck = new DuckUuidModel();
+        $duck->setRawAttributes(['foreignUuid' => 'nope']);
+
+        $this->expectException(InvalidBinaryUuidException::class);
+        $this->expectExceptionMessage('Column "foreignUuid"');
+        $duck->foreignUuid('foreignUuid');
     }
 }


### PR DESCRIPTION
Addresses the failure mode behind #14: when `$uuidColumn` points at a column that does not hold a binary UUID, the error came from inside `ramsey/uuid` and named nothing belonging to this package.

```
Ramsey\Uuid\Exception\InvalidArgumentException
  $bytes string should contain 16 characters.
  at vendor/ramsey/uuid/src/Codec/StringCodec.php:88
  1  Ramsey\Uuid\Codec\StringCodec::decodeBytes("uuid")
```

No model, no column, no hint at the setting to change. The reporter went looking in the vendor directory and patched the trait instead — understandable from that trace.

## What it looks like now

```
Verbanent\Uuid\Exceptions\InvalidBinaryUuidException:
  Column "id" on App\Models\Category does not contain a 16-byte binary UUID
  (found a 4-byte string). Point $uuidColumn on the model, or
  binary-uuid.default_column, at the column holding the binary UUID.
```

A value already in string form gets its own hint, since that means the column was written without the package:

```
  Column "uuid" on App\Models\Category does not contain a 16-byte binary UUID
  (found a UUID in string form). UUIDs are stored as 16 raw bytes, so this
  column was written without the package.
```

The offending value is described, never interpolated — no binary or user data lands in the message.

## Changes

**Read paths** — `uuid()` and `foreignUuid()` validate before calling `Uuid::fromBytes()`, throwing `InvalidBinaryUuidException` (new, extends `RuntimeException` alongside the existing exception). These only fire where an exception was already being thrown, so the change is the message, not the behaviour.

**Write path** — the `creating` hook no longer silently stores what it cannot encode. Values that are neither a UUID in string form nor 16 raw bytes previously fell through the `elseif` chain untouched and went to the database as-is; on MySQL outside strict mode that means a quiet truncation rather than an error. They now throw. This is the one behavioural change here, and it only affects inserts that were already writing wrong data.

It also removes a latent `TypeError`: non-string values reached `Uuid::isValid()`, which is declared `string`, so `$model->uuid = 3` blew up inside ramsey rather than reporting the real problem.

**`AccessedUnsetUuidPropertyException`** now names the column and model as well.

**README** gains a short Troubleshooting section, so the message is searchable for the next person who hits this.

## Not covered

The guards are value-based, so they cannot catch a `$uuidColumn` pointing at a column of the wrong *type* — writing 16 bytes into an `INT id` still fails at the database layer, as it should. What changes is the aftermath: where a lax MySQL truncates the write to `0`, reading it back now gives the message above instead of the ramsey trace.

I considered inferring the misconfiguration from `$incrementing` at insert time and rejected it — a model using the trait with a binary `id` column and the default `$incrementing = true` works today, and would start throwing.

## Tests

35 tests, 58 assertions, green (aside from the pre-existing `ReflectionMethod::setAccessible()` deprecation error that only reproduces on PHP 8.5 locally; CI is on 8.2). Five new tests cover both read-path messages, both write-path rejections, and the foreign-column path.

Two example models (`SheepUuidModel`, `GoatUuidModel`) come with them: this suite gives every test a fresh event dispatcher, so a model class booted by an earlier test no longer fires `creating`. Reusing `CatUuidModel` made the write-path tests silently not exercise the hook.

Public API grows an exception class and starts throwing on a previously-silent path, so this warrants a minor version — v1.11.0 rather than a patch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015hfqNHa1T563aGng4ecmH1